### PR TITLE
Fix mismatched command lines

### DIFF
--- a/mapping.tsv
+++ b/mapping.tsv
@@ -167,6 +167,9 @@ questionMarkPattern	?pattern
 backslashVpattern	\vpattern
 n	n
 N	N
+:PercentForwardSlashOldForwardSlashNewForwardSlashg	:%s/old/new/g
+:PercentForwardSlashOldForwardSlashNewForwardSlashgc	:%s/old/new/gc
+
 colonnoh	:noh[lsearch]
 coloncn	:cn[ext]
 coloncp	:cp[revious]
@@ -181,8 +184,9 @@ colontabc	:tabc[lose]
 colontabo	:tabo[nly]
 colontabdo	:tabdo
 colone	:e[dit] file
+:TabNew	:tabnew
 colonbd	:bd[elete]
-colonbnumber	:b[uffer]#
+:bnumber	:b<number of buffer>
 colonbfile	:b[uffer] file
 colonls	:ls
 colonsp	:sp[lit] file


### PR DESCRIPTION
## Summary
- correct mapping keys for several commands
- add new mappings for tabnew and substitution examples

## Testing
- `bash vcs.sh --all | head -n 5`
- `bash vcs.sh --all | grep -n "tabnew" -n`
- `bash vcs.sh --all | grep -n "b<number" -n`
- `bash vcs.sh --all | grep -n "%s/old/new/g" -n`


------
https://chatgpt.com/codex/tasks/task_b_6851c53ec33c832daa25402d7d85666a