### PR TITLE
Fix colon command handling

### DIFF
--- a/vcs.sh
+++ b/vcs.sh
@@ -111,11 +111,22 @@ fetch_data() {
         gsub("^[Cc]trl[Pp]lus"; "Ctrl+") |
         gsub("Plus"; "+")
       
-      # Colon commands
+      # Specific colon commands
+      elif . == "colonTerminal" then ":terminal"
+      elif . == "colonTabNew" then ":tabnew"
+      elif . == "colontabmove" then ":tabmove"
+      elif . == "colontabc" then ":tabc"
+      elif . == "colontabo" then ":tabo"
+      elif . == "colontabdo" then ":tabdo command"
+      elif . == "colonDiffthis" then ":diffthis"
+      elif . == "colonDiffupdate" then ":diffupdate"
+      elif . == "colonDiffoff" then ":diffoff"
+
+      # Generic colon commands
       elif test("^colon") then
         gsub("^colon"; ":") |
         gsub("Plus"; "+") |
-        gsub("([a-z])([A-Z])"; "\\1 \\2"; "g") |
+        gsub("(?<a>[a-z])(?<b>[A-Z])"; "\\(.a) \\(.b)") |
         ascii_downcase
       
       # Pattern matching commands
@@ -167,19 +178,6 @@ fetch_data() {
       elif . == "helpForKeyword" then ":h keyword"
       elif . == "saveAsFile" then ":sav file"
       elif . == "closePane" then ":q"
-      elif . == "colonTerminal" then ":terminal"
-      
-      # Window/tab management
-      elif . == "colonTabNew" then ":tabnew"
-      elif . == "colontabmove" then ":tabmove"
-      elif . == "colontabc" then ":tabc"
-      elif . == "colontabo" then ":tabo"
-      elif . == "colontabdo" then ":tabdo command"
-      
-      # Diff commands  
-      elif . == "colonDiffthis" then ":diffthis"
-      elif . == "colonDiffupdate" then ":diffupdate"
-      elif . == "colonDiffoff" then ":diffoff"
       
       # Pattern replacement for remaining items
       else


### PR DESCRIPTION
## Summary
- fix colon command regex to avoid `\1` output
- handle specific colon commands before generic ones

## Testing
- `bash -n vcs.sh`
- `./vcs.sh --category tabs | head`
- `./vcs.sh --search ':e' | head`


------
https://chatgpt.com/codex/tasks/task_b_6851e64a1a4c832db86eedacceabccdb